### PR TITLE
Fix content encoding in "Get object content" function

### DIFF
--- a/src/Objects.js
+++ b/src/Objects.js
@@ -92,11 +92,12 @@ class Objects {
 	 * Get file
 	 *
 	 * @param {String} path Path of file with container
+	 * @param {String|null|undefined} encoding If null, the body is returned as a Buffer by default it is utf8.
 	 *
 	 * @async
 	 * @return {Promise<{content: *, headers: Objects}>}
 	 */
-	get(path) {
+	get(path, encoding = undefined) {
 		return new Promise(async (resolve, reject) => {
 			try {
 				// check
@@ -129,8 +130,8 @@ class Objects {
 					headers: {
 						"X-Auth-Token": this.context.token,
 						"Accept": "application/json"
-					},
-                                        encoding: null
+					}, 
+					encoding: encoding
 				}, (err, res, body) => {
 					err = err || request.checkIfResponseIsError(res);
 					if (err) // noinspection ExceptionCaughtLocallyJS

--- a/src/Objects.js
+++ b/src/Objects.js
@@ -129,7 +129,8 @@ class Objects {
 					headers: {
 						"X-Auth-Token": this.context.token,
 						"Accept": "application/json"
-					}
+					},
+                                        encoding: null
 				}, (err, res, body) => {
 					err = err || request.checkIfResponseIsError(res);
 					if (err) // noinspection ExceptionCaughtLocallyJS


### PR DESCRIPTION
Fix content encoding in "Get object content" function.
Return binary data as a buffer instead of data encoded in utf8 (because data encoded in utf8 is corrupted for binary files).

@see https://www.npmjs.com/package/request#requestoptions-callback
> encoding - encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the default value of undefined) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.)